### PR TITLE
Use activity result after leaving `LoginActivity`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
-            android:name=".PasswordList"
+            android:name=".PasswordListActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>

--- a/app/src/main/java/es/wolfi/app/ResponseHandlers/CoreAPIGETResponseHandler.java
+++ b/app/src/main/java/es/wolfi/app/ResponseHandlers/CoreAPIGETResponseHandler.java
@@ -46,8 +46,9 @@ public class CoreAPIGETResponseHandler extends AsyncHttpResponseHandler {
         }
         if (statusCode == 401) {
             callback.onCompleted(new Exception("401"), null);
+        } else {
+            callback.onCompleted(new Exception(errorMessage), null);
         }
-        callback.onCompleted(new Exception(errorMessage), null);
     }
 
     @Override

--- a/app/src/main/java/es/wolfi/app/ResponseHandlers/CredentialDeleteResponseHandler.java
+++ b/app/src/main/java/es/wolfi/app/ResponseHandlers/CredentialDeleteResponseHandler.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import es.wolfi.app.passman.PasswordList;
+import es.wolfi.app.passman.PasswordListActivity;
 import es.wolfi.app.passman.R;
 import es.wolfi.app.passman.SettingValues;
 import es.wolfi.app.passman.SingleTon;
@@ -28,10 +28,10 @@ public class CredentialDeleteResponseHandler extends AsyncHttpResponseHandler {
     private final AtomicBoolean alreadySaving;
     private final ProgressDialog progress;
     private final View view;
-    private final PasswordList passwordListActivity;
+    private final PasswordListActivity passwordListActivity;
     private final FragmentManager fragmentManager;
 
-    public CredentialDeleteResponseHandler(AtomicBoolean alreadySaving, ProgressDialog progress, View view, PasswordList passwordListActivity, FragmentManager fragmentManager) {
+    public CredentialDeleteResponseHandler(AtomicBoolean alreadySaving, ProgressDialog progress, View view, PasswordListActivity passwordListActivity, FragmentManager fragmentManager) {
         super();
 
         this.alreadySaving = alreadySaving;

--- a/app/src/main/java/es/wolfi/app/ResponseHandlers/CredentialSaveResponseHandler.java
+++ b/app/src/main/java/es/wolfi/app/ResponseHandlers/CredentialSaveResponseHandler.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import es.wolfi.app.passman.PasswordList;
+import es.wolfi.app.passman.PasswordListActivity;
 import es.wolfi.app.passman.R;
 import es.wolfi.app.passman.SettingValues;
 import es.wolfi.app.passman.SingleTon;
@@ -29,10 +29,10 @@ public class CredentialSaveResponseHandler extends AsyncHttpResponseHandler {
     private final boolean updateCredential;
     private final ProgressDialog progress;
     private final View view;
-    private final PasswordList passwordListActivity;
+    private final PasswordListActivity passwordListActivity;
     private final FragmentManager fragmentManager;
 
-    public CredentialSaveResponseHandler(AtomicBoolean alreadySaving, boolean updateCredential, ProgressDialog progress, View view, PasswordList passwordListActivity, FragmentManager fragmentManager) {
+    public CredentialSaveResponseHandler(AtomicBoolean alreadySaving, boolean updateCredential, ProgressDialog progress, View view, PasswordListActivity passwordListActivity, FragmentManager fragmentManager) {
         super();
 
         this.alreadySaving = alreadySaving;

--- a/app/src/main/java/es/wolfi/app/passman/CopyTextItem.java
+++ b/app/src/main/java/es/wolfi/app/passman/CopyTextItem.java
@@ -151,6 +151,6 @@ public class CopyTextItem extends LinearLayout {
 
     @OnClick(R.id.open_url_btn_toggle_visible)
     public void openExternalURL() {
-        ((PasswordList) Objects.requireNonNull((Activity) getContext())).openExternalURL(this.text.getText().toString());
+        ((PasswordListActivity) Objects.requireNonNull((Activity) getContext())).openExternalURL(this.text.getText().toString());
     }
 }

--- a/app/src/main/java/es/wolfi/app/passman/CredentialAdd.java
+++ b/app/src/main/java/es/wolfi/app/passman/CredentialAdd.java
@@ -185,7 +185,7 @@ public class CredentialAdd extends Fragment implements View.OnClickListener {
         return new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                ((PasswordList) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialAddFile.ordinal());
+                ((PasswordListActivity) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialAddFile.ordinal());
             }
         };
     }
@@ -195,7 +195,7 @@ public class CredentialAdd extends Fragment implements View.OnClickListener {
             @Override
             public void onClick(View view) {
                 if (customFieldType.getSelectedItem().toString().equals("File")) {
-                    ((PasswordList) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialAddCustomFieldFile.ordinal());
+                    ((PasswordListActivity) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialAddCustomFieldFile.ordinal());
                 } else {
                     CustomField cf = new CustomField();
                     cf.setLabel("newLabel" + (cfed.getItemCount() + 1));
@@ -239,7 +239,7 @@ public class CredentialAdd extends Fragment implements View.OnClickListener {
 
         Context context = getContext();
         final ProgressDialog progress = ProgressUtils.showLoadingSequence(context);
-        final AsyncHttpResponseHandler responseHandler = new CredentialSaveResponseHandler(alreadySaving, false, progress, view, (PasswordList) getActivity(), getFragmentManager());
+        final AsyncHttpResponseHandler responseHandler = new CredentialSaveResponseHandler(alreadySaving, false, progress, view, (PasswordListActivity) getActivity(), getFragmentManager());
 
         this.credential.save(context, responseHandler);
     }

--- a/app/src/main/java/es/wolfi/app/passman/CredentialEdit.java
+++ b/app/src/main/java/es/wolfi/app/passman/CredentialEdit.java
@@ -201,7 +201,7 @@ public class CredentialEdit extends Fragment implements View.OnClickListener {
         return new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                ((PasswordList) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialEditFile.ordinal());
+                ((PasswordListActivity) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialEditFile.ordinal());
             }
         };
     }
@@ -211,7 +211,7 @@ public class CredentialEdit extends Fragment implements View.OnClickListener {
             @Override
             public void onClick(View view) {
                 if (customFieldType.getSelectedItem().toString().equals("File")) {
-                    ((PasswordList) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialEditCustomFieldFile.ordinal());
+                    ((PasswordListActivity) requireActivity()).selectFileToAdd(FileUtils.activityRequestFileCode.credentialEditCustomFieldFile.ordinal());
                 } else {
                     CustomField cf = new CustomField();
                     cf.setLabel("newLabel" + (cfed.getItemCount() + 1));
@@ -238,7 +238,7 @@ public class CredentialEdit extends Fragment implements View.OnClickListener {
 
                 Context context = getContext();
                 final ProgressDialog progress = ProgressUtils.showLoadingSequence(context);
-                final AsyncHttpResponseHandler responseHandler = new CredentialDeleteResponseHandler(alreadySaving, progress, view, (PasswordList) getActivity(), getFragmentManager());
+                final AsyncHttpResponseHandler responseHandler = new CredentialDeleteResponseHandler(alreadySaving, progress, view, (PasswordListActivity) getActivity(), getFragmentManager());
 
                 Date date = new Date();
                 credential.setDeleteTime(date.getTime());
@@ -280,7 +280,7 @@ public class CredentialEdit extends Fragment implements View.OnClickListener {
 
         Context context = getContext();
         final ProgressDialog progress = ProgressUtils.showLoadingSequence(context);
-        final AsyncHttpResponseHandler responseHandler = new CredentialSaveResponseHandler(alreadySaving, true, progress, view, (PasswordList) getActivity(), getFragmentManager());
+        final AsyncHttpResponseHandler responseHandler = new CredentialSaveResponseHandler(alreadySaving, true, progress, view, (PasswordListActivity) getActivity(), getFragmentManager());
 
         this.credential.update(context, responseHandler);
     }

--- a/app/src/main/java/es/wolfi/app/passman/LoginActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/LoginActivity.java
@@ -104,24 +104,22 @@ public class LoginActivity extends AppCompatActivity {
         final String user = input_user.getText().toString();
         final String pass = input_pass.getText().toString();
 
-        final Activity c = this;
-
         ton.addString(SettingValues.HOST.toString(), host);
         ton.addString(SettingValues.USER.toString(), user);
         ton.addString(SettingValues.PASSWORD.toString(), pass);
 
         Core.checkLogin(this, true, new FutureCallback<Boolean>() {
             @Override
-            public void onCompleted(Exception e, Boolean result) {
-                if (result) {
+            public void onCompleted(Exception e, Boolean loginSuccessful) {
+                if (loginSuccessful) {
                     settings.edit()
                             .putString(SettingValues.HOST.toString(), host)
                             .putString(SettingValues.USER.toString(), user)
                             .putString(SettingValues.PASSWORD.toString(), pass)
                             .apply();
 
-                    ton.getCallback(CallbackNames.LOGIN.toString()).onTaskFinished();
-                    c.finish();
+                    setResult(RESULT_OK);
+                    LoginActivity.this.finish();
                 } else {
                     ton.removeString(SettingValues.HOST.toString());
                     ton.removeString(SettingValues.USER.toString());
@@ -130,16 +128,5 @@ public class LoginActivity extends AppCompatActivity {
 
             }
         });
-    }
-
-    /**
-     * Displays this activity
-     * @param c
-     * @param cb
-     */
-    public static void launch(Context c, ICallback cb) {
-        SingleTon.getTon().addCallback(CallbackNames.LOGIN.toString(), cb);
-        Intent i = new Intent(c, LoginActivity.class);
-        c.startActivity(i);
     }
 }

--- a/app/src/main/java/es/wolfi/app/passman/PasswordList.java
+++ b/app/src/main/java/es/wolfi/app/passman/PasswordList.java
@@ -76,6 +76,9 @@ public class PasswordList extends AppCompatActivity implements
     SharedPreferences settings;
     SingleTon ton;
 
+    private static final int REQUEST_CODE_KEYGUARD = 0;
+    private static final int REQUEST_CODE_CREATE_DOCUMENT = 1;
+
     static boolean running = false;
 
     private AppCompatImageButton VaultLockButton;
@@ -148,7 +151,7 @@ public class PasswordList extends AppCompatActivity implements
 
             if (km.isKeyguardSecure()) {
                 Intent authIntent = km.createConfirmDeviceCredentialIntent(getString(R.string.unlock_passman), getString(R.string.unlock_passman_message_device_auth));
-                startActivityForResult(authIntent, 0);
+                startActivityForResult(authIntent, REQUEST_CODE_KEYGUARD);
             } else {
                 initialAuthentication(true);
             }
@@ -627,7 +630,7 @@ public class PasswordList extends AppCompatActivity implements
                                 // the system file picker when your app creates the document.
                                 //intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, pickerInitialUri);
 
-                                startActivityForResult(intent, 1);
+                                startActivityForResult(intent, REQUEST_CODE_CREATE_DOCUMENT);
                             }
                         }
                     } catch (JSONException ex) {
@@ -659,7 +662,7 @@ public class PasswordList extends AppCompatActivity implements
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (requestCode == 0) { //initial authentication
+        if (requestCode == REQUEST_CODE_KEYGUARD) { // initial authentication
             if (resultCode != RESULT_OK) {
                 finishAffinity();
                 return;
@@ -671,7 +674,7 @@ public class PasswordList extends AppCompatActivity implements
         if (resultCode != RESULT_OK)
             return;
 
-        if (requestCode == 1) { //download file
+        if (requestCode == REQUEST_CODE_CREATE_DOCUMENT) { // download file
             if (data != null) {
                 Uri uri = data.getData();
 

--- a/app/src/main/java/es/wolfi/app/passman/PasswordListActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/PasswordListActivity.java
@@ -67,7 +67,7 @@ import es.wolfi.passman.API.File;
 import es.wolfi.passman.API.Vault;
 import es.wolfi.utils.FileUtils;
 
-public class PasswordList extends AppCompatActivity implements
+public class PasswordListActivity extends AppCompatActivity implements
         VaultFragment.OnListFragmentInteractionListener,
         CredentialItemFragment.OnListFragmentInteractionListener,
         VaultLockScreen.VaultUnlockInteractionListener,
@@ -204,6 +204,7 @@ public class PasswordList extends AppCompatActivity implements
                     .setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left, R.anim.slide_in_left, R.anim.slide_out_right)
                     .replace(R.id.content_password_list, new VaultFragment(), "vaults")
                     .commit();
+            Log.d("PL", "committed transaction");
         } else {
             final ProgressDialog progress = getProgressDialog();
             progress.show();

--- a/app/src/main/java/es/wolfi/app/passman/PasswordListActivity.java
+++ b/app/src/main/java/es/wolfi/app/passman/PasswordListActivity.java
@@ -77,7 +77,8 @@ public class PasswordListActivity extends AppCompatActivity implements
     SingleTon ton;
 
     private static final int REQUEST_CODE_KEYGUARD = 0;
-    private static final int REQUEST_CODE_CREATE_DOCUMENT = 1;
+    private static final int REQUEST_CODE_AUTHENTICATE = 1;
+    private static final int REQUEST_CODE_CREATE_DOCUMENT = 2;
 
     static boolean running = false;
 
@@ -159,20 +160,19 @@ public class PasswordListActivity extends AppCompatActivity implements
             final ProgressDialog progress = getProgressDialog();
             progress.show();
 
-            final AppCompatActivity self = this;
             Core.checkLogin(this, false, new FutureCallback<Boolean>() {
                 @Override
-                public void onCompleted(Exception e, Boolean result) {
+                public void onCompleted(Exception e, Boolean loggedIn) {
                     // To dismiss the dialog
                     progress.dismiss();
 
-                    if (result) {
+                    if (loggedIn) {
                         showVaults();
-                        return;
+                    } else {
+                        // If not logged in, show login form!
+                        Intent intent = new Intent(PasswordListActivity.this, LoginActivity.class);
+                        startActivityForResult(intent, REQUEST_CODE_AUTHENTICATE);
                     }
-
-                    // If not logged in, show login form!
-                    LoginActivity.launch(self, () -> showVaults());
                 }
             });
 
@@ -467,16 +467,16 @@ public class PasswordListActivity extends AppCompatActivity implements
             progress.show();
             Core.checkLogin(this, false, new FutureCallback<Boolean>() {
                 @Override
-                public void onCompleted(Exception e, Boolean result) {
+                public void onCompleted(Exception e, Boolean loggedIn) {
                     progress.dismiss();
 
-                    if (result) {
+                    if (loggedIn) {
                         showVaults();
-                        return;
+                    } else {
+                        // If not logged in, show login form!
+                        Intent intent = new Intent(PasswordListActivity.this, LoginActivity.class);
+                        startActivityForResult(intent, REQUEST_CODE_AUTHENTICATE);
                     }
-
-                    // If not logged in, show login form!
-                    LoginActivity.launch(getParent(), () -> showVaults());
                 }
             });
         }
@@ -672,6 +672,17 @@ public class PasswordListActivity extends AppCompatActivity implements
             initialAuthentication(true);
         }
 
+        if (requestCode == REQUEST_CODE_AUTHENTICATE) {
+            if (resultCode == RESULT_CANCELED) {
+                // User cancelled login (i.e. touched "back" button)
+                finish();
+            } else {
+                // Proceed
+                showVaults();
+            }
+        }
+
+        // Following cases should only be handled on positive result
         if (resultCode != RESULT_OK)
             return;
 

--- a/app/src/main/java/es/wolfi/app/passman/Settings.java
+++ b/app/src/main/java/es/wolfi/app/passman/Settings.java
@@ -209,9 +209,9 @@ public class Settings extends Fragment {
                     settings.edit().putString(SettingValues.USER.toString(), settings_nextcloud_user.getText().toString()).commit();
                     settings.edit().putString(SettingValues.PASSWORD.toString(), settings_nextcloud_password.getText().toString()).commit();
 
-                    Objects.requireNonNull(((PasswordList) getActivity())).applyNewSettings(true);
+                    Objects.requireNonNull(((PasswordListActivity) getActivity())).applyNewSettings(true);
                 } else {
-                    Objects.requireNonNull(((PasswordList) getActivity())).applyNewSettings(false);
+                    Objects.requireNonNull(((PasswordListActivity) getActivity())).applyNewSettings(false);
                 }
             }
         };

--- a/app/src/main/java/es/wolfi/app/passman/SingleTon.java
+++ b/app/src/main/java/es/wolfi/app/passman/SingleTon.java
@@ -30,10 +30,8 @@ public class SingleTon {
     protected ConcurrentHashMap<String, View.OnClickListener> _click;
     protected ConcurrentHashMap<String, Object>               _extra;
     protected ConcurrentHashMap<String, String>               _string;
-    protected ConcurrentHashMap<String, ICallback>            _callback;
 
     public SingleTon(){
-        _callback   = new ConcurrentHashMap<String, ICallback>();
         _string     = new ConcurrentHashMap<String, String>();
         _click      = new ConcurrentHashMap<String, View.OnClickListener>();
         _extra      = new ConcurrentHashMap<String, Object>();
@@ -49,18 +47,6 @@ public class SingleTon {
 
     public String getString(String name){
         return _string.get(name);
-    }
-
-    public void addCallback(String name, ICallback c){
-        _callback.put(name, c);
-    }
-
-    public ICallback getCallback(String name){
-        return _callback.get(name);
-    }
-
-    public void removeCallback(String name){
-        _callback.remove(name);
     }
 
     public void addExtra(String name, Object data){

--- a/app/src/main/java/es/wolfi/utils/FileUtils.java
+++ b/app/src/main/java/es/wolfi/utils/FileUtils.java
@@ -30,7 +30,8 @@ public class FileUtils {
      * credentialAddCustomFieldFile     5
      */
     public enum activityRequestFileCode {
-        padding0, padding1, credentialEditFile, credentialEditCustomFieldFile, credentialAddFile, credentialAddCustomFieldFile
+        padding0, padding1, padding2,
+        credentialEditFile, credentialEditCustomFieldFile, credentialAddFile, credentialAddCustomFieldFile
     }
 
     /**

--- a/app/src/main/res/layout/activity_password_list.xml
+++ b/app/src/main/res/layout/activity_password_list.xml
@@ -27,7 +27,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context="es.wolfi.app.passman.PasswordList">
+    tools:context="es.wolfi.app.passman.PasswordListActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/content_password_list.xml
+++ b/app/src/main/res/layout/content_password_list.xml
@@ -29,6 +29,6 @@
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:showIn="@layout/activity_password_list"
-    tools:context="es.wolfi.app.passman.PasswordList">
+    tools:context="es.wolfi.app.passman.PasswordListActivity">
 
 </FrameLayout>

--- a/app/src/main/res/menu/menu_credential_display.xml
+++ b/app/src/main/res/menu/menu_credential_display.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="es.wolfi.app.passman.PasswordList" >
+    tools:context="es.wolfi.app.passman.PasswordListActivity" >
 
     <item android:id="@+id/action_refresh_credentials"
         android:title="@string/action_refresh"

--- a/app/src/main/res/menu/menu_credential_item_fragment.xml
+++ b/app/src/main/res/menu/menu_credential_item_fragment.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="es.wolfi.app.passman.PasswordList" >
+    tools:context="es.wolfi.app.passman.PasswordListActivity" >
 
     <item android:id="@+id/action_refresh"
         android:title="@string/action_refresh"

--- a/app/src/main/res/menu/menu_password_list.xml
+++ b/app/src/main/res/menu/menu_password_list.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="es.wolfi.app.passman.PasswordList" >
+    tools:context="es.wolfi.app.passman.PasswordListActivity" >
     <item android:id="@+id/action_settings"
         android:title="@string/action_settings"
         android:orderInCategory="104"


### PR DESCRIPTION
I suspect that the cause of the crash `IllegalStateException: Can not perform this action after onSaveInstanceState` is a race condition where `LoginActivity` may not close quickly enough after calling the `PasswordList` activity callback, causing the latter to attempt adding committing a fragment transaction while the activity is paused (see [`Activity` lifecycle chart](https://developer.android.com/guide/components/images/activity_lifecycle.png)).

To reproduce, one may remove the following line, causing the application to always crash after performing a login attempt through the login activity:

https://github.com/binsky08/passman-android/blob/cfc91a9663708b26df9eb0122a31be6dde380b12/app/src/main/java/es/wolfi/app/passman/LoginActivity.java#L124

The construct that uses a callback between activities seems rather unstable to me. Hence, I suggest replacing it by using `startActivityForResult`, as done in this PR.

This PR also:

* Adds constants for the other two not-yet-constant-ized callbacks in `PasswordList`
* Renames `PasswordList` to `PasswordListActivity` because I kept being confused about it
* Closes the application upon canceling login (to do: behave correctly after starting application again)
* Fixes a problem where `LoginActivity` would be opened twice at once if invalid credentials are provided

See the commit log for details.  